### PR TITLE
X2-1617 Add http config to x2-connector and fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@
 ```JavaScript
 const x2Connector = require('@fintechdev/x2-connector');
 
-x2Connector.init({ configPath: '/cfg/config.json' })
+x2Connector.init({
+  configPath: '/cfg/config.json',
+  httpConfig: {
+    mode : 'no-cors',
+    cache: 'default'
+  }
+})
 .then(() => {
   // Init App
 });

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "eslint": "eslint . --ext .js"
   },
   "dependencies": {
+    "@fintechdev/x2-service-storage": "0.0.2",
     "relign": "^0.5.0",
     "trae": "0.0.10",
     "whatwg-fetch": "^1.0.0"
   },
   "devDependencies": {
-    "@fintechdev/x2-service-storage": "0.0.2",
     "eslint": "^3.9.1",
     "eslint-config-airbnb": "^12.0.0",
     "eslint-plugin-import": "^1.16.0",
@@ -30,8 +30,7 @@
     "jest": "^16.0.2",
     "node-localstorage": "^1.3.0",
     "pre-commit": "^1.1.3",
-    "relign": "^0.5.0",
-    "sinon": "^1.17.6"
+    "relign": "^0.5.0"
   },
   "pre-commit": [
     "eslint"
@@ -46,11 +45,10 @@
       }
     },
     "collectCoverageFrom": [
-      "!**/node_modules/**",
       "src/**"
     ],
     "testPathDirs": [
-      "test/"
+      "test/specs/"
     ],
     "setupTestFrameworkScriptFile": "test/setup.js"
   }

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,10 +1,25 @@
-const jsdom        = require('jsdom');
-const LocalStorage = require('node-localstorage').LocalStorage;
+const storageMock = () => {
+  const storage = {};
 
-global.localStorage   = new LocalStorage('test/localStorageTemp');
-global.sessionStorage = new LocalStorage('test/sessionStorageTemp');
+  return {
+    setItem(key, value) {
+      storage[key] = value || '';
+    },
+    getItem(key) {
+      return storage[key] || null;
+    },
+    removeItem(key) {
+      delete storage[key];
+    },
+    get length() {
+      return Object.keys(storage).length;
+    },
+    key(i) {
+      const keys = Object.keys(storage);
+      return keys[i] || null;
+    }
+  };
+};
 
-
-global.window = jsdom.jsdom('').defaultView;
-global.window.localStorage   = global.localStorage;
-global.window.sessionStorage = global.sessionStorage;
+Object.defineProperty(window, 'localStorage',   { value: storageMock() });
+Object.defineProperty(window, 'sessionStorage', { value: storageMock() });

--- a/test/specs/index.spec.js
+++ b/test/specs/index.spec.js
@@ -1,9 +1,13 @@
 /* global describe it expect */
 
-const fetchMock   = require('fetch-mock');
-const x2Connector = require('../src');
+const fetchMock = require('fetch-mock');
+
+const x2Connector = require('../../src');
+const trae        = require('trae');
 
 describe('HTTP -> http', () => {
+
+  const baseUrl = 'http://localhost:8080';
 
   it('extends from EventEmitter class so it should have the "emit" and "on" methods available', () => {
     expect(x2Connector.emit).toBeTruthy();
@@ -11,11 +15,9 @@ describe('HTTP -> http', () => {
   });
 
   it('Initialize attributes', () => {
-    expect(x2Connector.token).toBe(null);
+    expect(x2Connector.token).toEqual(null);
     expect(x2Connector.tokenExpiriesAt).toBe(null);
     expect(x2Connector._tokenDuration).toBe(1000 * 60 * 20);
-
-    expect(x2Connector._baseUrl).toEqual('http://localhost:8080');
 
     expect(x2Connector._inactivityCheckInterval).toBe(null);
     expect(x2Connector._inactivityTimeout).toBe(null);
@@ -25,29 +27,26 @@ describe('HTTP -> http', () => {
 
   describe('init()', () => {
     it('Initilize default attributes', () => {
-      const baseUrl = x2Connector._baseUrl;
-      const middlewares = {
-        config  : [() => {}],
-        reject  : [() => {}],
-        fullfill: [() => {}]
-      };
+      const httpConfig = { baseUrl };
 
-      x2Connector.init({ middlewares, baseUrl });
-
-      expect(x2Connector._baseUrl).toBe(baseUrl);
+      return x2Connector.init({ httpConfig })
+      .then(() => {
+        expect(trae.baseUrl()).toBe(baseUrl);
+      });
     });
   });
 
   describe('get()', () => {
     it('makes a GET request to baseURL + path and responds 200 status code', () => {
-      fetchMock.mock(`${x2Connector._baseUrl}/foo`, {
-        status: 200,
-        body  : { foo: 'bar' }
+      fetchMock.mock(`${baseUrl}/foo`, {
+        status : 200,
+        body   : { foo: 'bar' },
+        headers: { 'Content-Type': 'application/json' }
       });
 
-      x2Connector.get('/foo')
+      return x2Connector.get('/foo')
       .then((res) => {
-        expect(res).toBe({ foo: 'bar' });
+        expect(res).toEqual({ foo: 'bar' });
         fetchMock.restore();
       });
     });
@@ -55,16 +54,17 @@ describe('HTTP -> http', () => {
 
   describe('post()', () => {
     it('makes a POST request to baseURL + path', () => {
-      fetchMock.mock(`${x2Connector._baseUrl}/foo`, {
-        status: 200,
-        body  : { foo: 'bar' }
+      fetchMock.mock(`${baseUrl}/foo`, {
+        status : 200,
+        body   : { foo: 'bar' },
+        headers: { 'Content-Type': 'application/json' }
       }, {
         method: 'POST'
       });
 
-      x2Connector.post('/foo')
+      return x2Connector.post('/foo')
       .then((res) => {
-        expect(res).toBe({ foo: 'bar' });
+        expect(res).toEqual({ foo: 'bar' });
         fetchMock.restore();
       });
     });
@@ -72,16 +72,17 @@ describe('HTTP -> http', () => {
 
   describe('put()', () => {
     it('makes a PUT request to baseURL + path', () => {
-      fetchMock.mock(`${x2Connector._baseUrl}/foo`, {
-        status: 200,
-        body  : { foo: 'bar' }
+      fetchMock.mock(`${baseUrl}/foo`, {
+        status : 200,
+        body   : { foo: 'bar' },
+        headers: { 'Content-Type': 'application/json' }
       }, {
         method: 'PUT'
       });
 
-      x2Connector.put('/foo')
+      return x2Connector.put('/foo')
       .then((res) => {
-        expect(res).toBe({ foo: 'bar' });
+        expect(res).toEqual({ foo: 'bar' });
         fetchMock.restore();
       });
     });
@@ -89,33 +90,35 @@ describe('HTTP -> http', () => {
 
   describe('delete()', () => {
     it('makes a DEL request to baseURL + path', () => {
-      fetchMock.mock(`${x2Connector._baseUrl}/foo`, {
+      fetchMock.mock(`${baseUrl}/foo`, {
         status: 200,
-        body  : { foo: 'bar' }
+        body   : { foo: 'bar' },
+        headers: { 'Content-Type': 'application/json' }
       }, {
         method: 'DELETE'
       });
 
-      x2Connector.delete('/foo')
+      return x2Connector.delete('/foo')
       .then((res) => {
-        expect(res).toBe({ foo: 'bar' });
+        expect(res).toEqual({ foo: 'bar' });
         fetchMock.restore();
       });
     });
   });
 
   describe('login()', () => {
-    it('makes a post /token to login through X2 API', () => {
-      fetchMock.mock(`$${x2Connector._baseUrl}/token`, {
-        status: 200,
-        body  : { token: '1234' }
+    it('makes a post to /token through X2 API to login', () => {
+      fetchMock.mock(`${baseUrl}/token`, {
+        status : 200,
+        body   : { token: '1234' },
+        headers: { 'Content-Type': 'application/json' }
       }, {
         method: 'POST'
       });
 
-      x2Connector.login('user', 'password')
+      return x2Connector.login('user', 'password')
       .then((res) => {
-        expect(res).toBe({ token: '1234' });
+        expect(x2Connector.token).toBe('1234');
       });
     });
   });


### PR DESCRIPTION
Adding httpConfig attribute to the init method allows x2-connector to use `fetch` / `trae` default options, for example: `mode: 'no-cors'` this solved a core problem that I was having locally.

Also this change will allow us to change the cache property.